### PR TITLE
added quotes around appname parameter in cordova create command

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1521,7 +1521,7 @@
       if (appname) {
         var self = this,
           dirName = appname,
-          cmd = '"' + path.join(__dirname, '..', 'node_modules', '.bin', 'cordova') + '"' + ' create  ' + '"' +  workingDir + '" ' + packageId + '  ' + appname,
+          cmd = '"' + path.join(__dirname, '..', 'node_modules', '.bin', 'cordova') + '"' + ' create  ' + '"' +  workingDir + '" ' + packageId + '  "' + appname + '"',
           childProcess = exec(cmd);
         childProcess.on('uncaughtException', function(err) {
           deferred.reject(err);


### PR DESCRIPTION
Hi Andreas,

I have now added quotes, which also solved an issue which was not allowing project names with spaces in them. 

Without quotes cordova create command would fail silently without creating project and without executing any injected command.
