### PR TITLE
added limit for checking number of local files before upload 

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -868,7 +868,8 @@
   Monaca.prototype.getLocalProjectFiles = function(projectDir) {
     var deferred = Q.defer();
 
-    var getFileChecksum = function(file) {
+    var qLimit = qlimit(100);
+    var getFileChecksum = qLimit(function(file) {
       var deferred = Q.defer();
 
       fs.readFile(file, function(error, data) {
@@ -881,7 +882,7 @@
       });
 
       return deferred.promise;
-    };
+    });
 
     fs.exists(projectDir, function(exists) {
       if (exists) {


### PR DESCRIPTION
Hi @masahirotanaka 

This is in reference to monaca upload [issue](https://github.com/monaca/monaca-cli/issues/27) in monaca-cli where if there are huge number of files ( > 200 ) to be uploaded then it throws `Error: EMFILE, open 'XXXXX' error`

Now I have put limit of checking 100 files at a time which resolves this error.
