### PR TITLE
Added support for 'delete' and 'dryrun' options in monaca upload and download methods.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "decompress": "^2.3.0",
     "decompress-unzip": "^3.2.2",
     "extend": "^2.0.0",
+    "glob": "^5.0.14",
     "lockfile": "^1.0.0",
     "nconf": "^0.7.1",
     "padlock": "^1.1.2",

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1319,7 +1319,7 @@
             	}
 
               if (allowFiles.length > 0) {
-                // Only include files in /www, /merges and /plugins folders unless they are mentioned in .monacaignore file.
+                // Only include files in /www, /merges and /plugins folders.
                 if (!/^\/(www\/|merges\/|plugins\/|[^/]*$)/.test(fn)) {
                   return false;
                 } else {

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -230,11 +230,14 @@
       ignoreList = fs.readFileSync(path.join(projectDir, ".monacaignore"), {
           "encoding": "utf8"
         })
-        .split("\n")
+        .split("\r\n") // Split by \r\n.
+        .map(function(ele) { return ele.split("\n")}) // Split each array element from previous step by \n again.
+        .reduce(function(a,b) { return a.concat(b)}) // Now concat them into one array.
         .filter(function(n) {
-          return n !== "" && n.indexOf("#") !== 0;
+          return n.trim() !== "" && n.indexOf("#") !== 0;
         });
     }
+    console.log("ignoreList " + JSON.stringify(ignoreList,null,2));
     if (ignoreList.length > 0) {
       if (os.platform() === 'win32') {
         projectDir = projectDir.replace(/\\/g,"/");
@@ -1267,7 +1270,7 @@
                   filesToBeDeleted[f] = remoteFiles[f];
                 }
               }
-              if (options && !options.dryrun && options.delete) {                
+              if (options && !options.dryrun && options.delete) {
                     this._deleteFileFromCloud(projectId, Object.keys(filesToBeDeleted)).then(
                     function() {
                       console.log(Object.keys(filesToBeDeleted)
@@ -1280,7 +1283,7 @@
                     function(err) {
                       console.log("\nfile delete error ->  : " + JSON.stringify(err));
                     }
-                  )                
+                  )
               }
 
             // Filter out directories and unchanged files.
@@ -1466,8 +1469,7 @@
                     // Allow this file since it exists in the allowed list of files.
                   } else {
                     // Check if this file already exists locally. 
-                    // If yes then dont donwload it. If no, then download it.
-
+                    // If yes then don't donwload it. If no, then download it.
                     if (fs.existsSync(path.join(projectDir,file))) {
                       delete remoteFiles[file];
                     }

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -462,8 +462,8 @@
 
  Monaca.prototype._deleteFileFromCloud = function(projectId, remotePath) {
     var deferred = Q.defer();
-    this._post('/project/' + projectId + '/file/delete', {
-      path: remotePath
+    this._post('/project/' + projectId + '/file/remove', {
+      paths: remotePath
     }).then(
       function() {
         deferred.resolve(remotePath);
@@ -1265,19 +1265,19 @@
                 // If file on Monaca Cloud doesn't exist locally then it should be deleted from Cloud.
                 if (!localFiles.hasOwnProperty(f) && remoteFiles[f].type !== 'dir') {
                   filesToBeDeleted[f] = remoteFiles[f];
-                  if (options && !options.dryrun && options.delete) {
-                    (function(file){
-                        this._deleteFileFromCloud(projectId, f).then(
-                        function() {
-                          console.log("deleted -> " + file);
-                        },
-                        function(err) {
-                          console.log("delete error -> " + file + " : " + JSON.stringify(err));
-                        }
-                      )
-                    }.bind(this)(f));
-                  }
                 }
+              }
+              if (options && !options.dryrun && options.delete) {
+                (function(file){
+                    this._deleteFileFromCloud(projectId, Object.keys(filesToBeDeleted)).then(
+                    function() {
+                      console.log("\nDeleted following files.\n" + Object.keys(filesToBeDeleted).join("\n"));
+                    },
+                    function(err) {
+                      console.log("\ndelete error -> " + file + " : " + JSON.stringify(err));
+                    }
+                  )
+                }.bind(this)(f));
               }
 
             // Filter out directories and unchanged files.

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -232,11 +232,11 @@
         })
         .split("\n")
         .filter(function(n) {
-          return n != ""
+          return n !== "" && n.indexOf("#") !== 0;
         });
     }
     if (ignoreList.length > 0) {
-      if (os.platform() == 'win32') {
+      if (os.platform() === 'win32') {
         projectDir = projectDir.replace(/\\/g,"/");
       }
 

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1267,8 +1267,7 @@
                   filesToBeDeleted[f] = remoteFiles[f];
                 }
               }
-              if (options && !options.dryrun && options.delete) {
-                (function(file){
+              if (options && !options.dryrun && options.delete) {                
                     this._deleteFileFromCloud(projectId, Object.keys(filesToBeDeleted)).then(
                     function() {
                       console.log(Object.keys(filesToBeDeleted)
@@ -1279,10 +1278,9 @@
                       );
                     },
                     function(err) {
-                      console.log("\ndelete error -> " + file + " : " + JSON.stringify(err));
+                      console.log("\nfile delete error ->  : " + JSON.stringify(err));
                     }
-                  )
-                }.bind(this)(f));
+                  )                
               }
 
             // Filter out directories and unchanged files.

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1271,7 +1271,12 @@
                 (function(file){
                     this._deleteFileFromCloud(projectId, Object.keys(filesToBeDeleted)).then(
                     function() {
-                      console.log("\nDeleted following files.\n" + Object.keys(filesToBeDeleted).join("\n"));
+                      console.log(Object.keys(filesToBeDeleted)
+                      .map(function(f) {
+                        return "deleted -> " + f;
+                      })
+                      .join("\n")
+                      );
                     },
                     function(err) {
                       console.log("\ndelete error -> " + file + " : " + JSON.stringify(err));

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1231,7 +1231,7 @@
    *     }
    *   );
    */
-  Monaca.prototype.uploadProject = function(projectDir) {
+  Monaca.prototype.uploadProject = function(projectDir, options) {
     var deferred = Q.defer();
 
     localProperties.get(projectDir, 'project_id').then(
@@ -1295,6 +1295,17 @@
             };
 
             var keys = Object.keys(localFiles).filter(fileFilter);
+
+            // If dryrun option is set, just return the files to be uploaded.
+            if (options && options.dryrun) {
+              var data = {};
+              for(var i in keys) {
+                if (localFiles[keys[i]]) {
+                  data[keys[i]] = localFiles[keys[i]];
+                }
+              }
+              return deferred.resolve(data);
+            }
 
             var totalLength = keys.length,
               currentIndex = 0,
@@ -1379,7 +1390,7 @@
    *     }
    *   );
    */
-  Monaca.prototype.downloadProject = function(projectDir) {
+  Monaca.prototype.downloadProject = function(projectDir, options) {
     var deferred = Q.defer();
     localProperties.get(projectDir, 'project_id').then(
       function(projectId) {
@@ -1413,6 +1424,11 @@
 
             // Filter files to be downloaded according to .monacaignore file.
             filterFiles();
+
+            // If dryrun option is set, just return the files to be downloaded.
+            if (options && options.dryrun) {
+              return deferred.resolve(remoteFiles);
+            }
 
             var totalLength = Object.keys(remoteFiles).length,
               currentIndex = 0,

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -246,7 +246,7 @@
             return "**/" + rule;
           })
         }
-      )        
+      )
     }
     return allFiles;
   };
@@ -1242,7 +1242,7 @@
 
             // Fetch list of files after ignoring files/directories in .monacaignore file.
             var allowFiles = this._filterIgnoreList(projectDir);
-            
+
             var fileFilter = function(fn) {
               // Exclude hidden files and folders.
               if (fn.indexOf('/.') >= 0) {
@@ -1271,16 +1271,16 @@
             	if (/^\/platforms\/(chrome|winrt)\/[^\/]+$/.test(fn)) {
             		return true;
             	}
-              
+
               if (allowFiles.length > 0) {
                 // Only include files in /www, /merges and /plugins folders unless they are mentioned in .monacaignore file.
-                if (!/^\/(www\/|merges\/|plugins\/|[^/]*$)/.test(fn)) {                
+                if (!/^\/(www\/|merges\/|plugins\/|[^/]*$)/.test(fn)) {
                   return false;
                 } else {
                   // Check if file is present in one of the /www, /merges and /plugins folders and also in list of allowed files.
-                  if (allowFiles.indexOf(path.join(projectDir,fn)) >= 0) {                    
+                  if (allowFiles.indexOf(path.join(projectDir,fn)) >= 0) {
                     return true;
-                  } else {                    
+                  } else {
                     return false;
                   }
                 }
@@ -1392,13 +1392,13 @@
 
             var filterFiles = function() {
               if (allowFiles.length > 0) {
-                for (var file in remoteFiles) {                  
+                for (var file in remoteFiles) {
                   if (allowFiles.indexOf(path.join(projectDir,file)) >= 0) {
                     // Allow this file since it exists in the allowed list of files.
                   } else {
                     // Check if this file already exists locally. 
                     // If yes then dont donwload it. If no, then download it.
-                    if (fs.existsSync(path.join(projectDir,file))) {                      
+                    if (fs.existsSync(path.join(projectDir,file))) {
                       delete remoteFiles[file];
                     }
                   }

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1261,7 +1261,7 @@
 
               var filesToBeDeleted = {};
 
-              for(var f in remoteFiles) {
+              for (var f in remoteFiles) {
                 // If file on Monaca Cloud doesn't exist locally then it should be deleted from Cloud.
                 if (!localFiles.hasOwnProperty(f) && remoteFiles[f].type !== 'dir') {
                   filesToBeDeleted[f] = remoteFiles[f];
@@ -1340,7 +1340,7 @@
             // If dryrun option is set, just return the files to be uploaded.
             if (options && options.dryrun) {
               var data = {};
-              for(var i in keys) {
+              for (var i in keys) {
                 if (localFiles[keys[i]]) {
                   data[keys[i]] = localFiles[keys[i]];
                 }
@@ -1445,11 +1445,11 @@
             // Fetch list of files after ignoring files/directories in .monacaignore file.
             var allowFiles = this._filterIgnoreList(projectDir);
 
-            for(var f in localFiles) {
+            for (var f in localFiles) {
               // If file is not present on Monaca cloud but is present locally and it is not listed under .monacaignore, then it must be deleted.
               if (!remoteFiles.hasOwnProperty(f) && localFiles[f].type !== 'dir'  && allowFiles.indexOf((os.platform() === 'win32' ? projectDir.replace(/\\/g,"/") : projectDir) + f) >= 0) {
                 filesToBeDeleted[f] = localFiles[f];
-                if(options && !options.dryrun && options.delete) {
+                if (options && !options.dryrun && options.delete) {
                   fs.unlinkSync(path.join(projectDir, f));
                   console.log("deleted -> " + path.join(projectDir, f));
                 }

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -236,6 +236,10 @@
         });
     }
     if (ignoreList.length > 0) {
+      if (os.platform() == 'win32') {
+        projectDir = projectDir.replace(/\\/g,"/");
+      }
+
       // We have to append '/**' to get all the subdirectories recursively.
       allFiles = glob.sync(projectDir + "/**", 
         {
@@ -1278,7 +1282,7 @@
                   return false;
                 } else {
                   // Check if file is present in one of the /www, /merges and /plugins folders and also in list of allowed files.
-                  if (allowFiles.indexOf(path.join(projectDir,fn)) >= 0) {
+                  if (allowFiles.indexOf((os.platform() === 'win32' ? projectDir.replace(/\\/g,"/") : projectDir) + fn) >= 0) {
                     return true;
                   } else {
                     return false;
@@ -1393,11 +1397,12 @@
             var filterFiles = function() {
               if (allowFiles.length > 0) {
                 for (var file in remoteFiles) {
-                  if (allowFiles.indexOf(path.join(projectDir,file)) >= 0) {
+                  if (allowFiles.indexOf((os.platform() === 'win32' ? projectDir.replace(/\\/g,"/") : projectDir) + file) >= 0) {
                     // Allow this file since it exists in the allowed list of files.
                   } else {
                     // Check if this file already exists locally. 
                     // If yes then dont donwload it. If no, then download it.
+
                     if (fs.existsSync(path.join(projectDir,file))) {
                       delete remoteFiles[file];
                     }


### PR DESCRIPTION
Hi @masahirotanaka 

Please review this pull request. This request also contains implementation for .monacaignore functionality. So you can directly review this branch and ignore [monacaignore](https://github.com/monaca/monaca-lib/pull/25) pull request.
