### PR TITLE
File filter implemented before calculating checksum on files

### DIFF
--- a/src/localkit.js
+++ b/src/localkit.js
@@ -915,23 +915,24 @@
     var deferred = Q.defer();
 
     if (this.projects.hasOwnProperty(projectId)) {
+      this.monaca.getLocalProjectFiles(this.projects.getProjectById(projectId).path, {
+        filter : function(fn) {
+          var key = path.join('/', fn);
+          key = key.split(path.sep).join('/');
 
-      this.monaca.getLocalProjectFiles(this.projects.getProjectById(projectId).path).then(
+          // Exclude hidden files and folders.
+          if (key.indexOf('/.') >= 0) {
+            return false;
+          }
+
+          // Only include files in /www folder.
+          return /^\/(www\/|[^/]*$)/.test(key);
+          }
+        }).then(
         function(files) {
           var tmp = {};
 
-          var fileFilter = function(fn) {
-            // Exclude hidden files and folders.
-            if (fn.indexOf('/.') >= 0) {
-              return false;
-            }
-
-            // Only include files in /www folder.
-            return /^\/(www\/|[^/]*$)/.test(fn);
-          };
-
-          var filenames = Object.keys(files).filter(fileFilter);
-
+          var filenames = Object.keys(files);
           for (var i = 0, l = filenames.length; i < l; i ++) {
             var filename = filenames[i];
 

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -948,16 +948,16 @@
         });
 
         var filterFiles = function(fn) {
-            var key = path.join('/', fn);
-            key = key.split(path.sep).join('/');
+          var key = path.join('/', fn);
+          key = key.split(path.sep).join('/');
 
-            // Exclude hidden files and folders.
-            if (fn.indexOf('/.') >= 0) {
-              return false;
-            }
+          // Exclude hidden files and folders.
+          if (fn.indexOf('/.') >= 0) {
+            return false;
+          }
 
-            // Only include files in /www folder.
-            return /^\/(www\/|[^/]*$)/.test(key);
+          // Only include files in /www folder.
+          return /^\/(www\/|[^/]*$)/.test(key);
         };
 
         var filteredList = list.filter(filterFiles);

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -908,6 +908,7 @@
    * @description
    *   Fetch a list of files and directories for a local project.
    * @param {string} projectDir - Path to project.
+   * @param {Object} [options] Parameters like filter to filter from list of files.   
    * @return {Promise}
    * @example
    *   monaca.getLocalProjectFiles = function('/some/directory').then(
@@ -919,7 +920,7 @@
    *     }
    *   );
    */
-  Monaca.prototype.getLocalProjectFiles = function(projectDir) {
+  Monaca.prototype.getLocalProjectFiles = function(projectDir, options) {
     var deferred = Q.defer();
 
     var qLimit = qlimit(100);
@@ -947,21 +948,10 @@
           return name.indexOf('node_modules') !== 0;
         });
 
-        var filterFiles = function(fn) {
-          var key = path.join('/', fn);
-          key = key.split(path.sep).join('/');
-
-          // Exclude hidden files and folders.
-          if (fn.indexOf('/.') >= 0) {
-            return false;
-          }
-
-          // Only include files in /www folder.
-          return /^\/(www\/|[^/]*$)/.test(key);
-        };
-
-        var filteredList = list.filter(filterFiles);
-
+        var filteredList = list;
+        if (options && options.filter && typeof options.filter === 'function') {
+          filteredList = list.filter(options.filter);
+        }
         filteredList.forEach(function(file) {
           var obj = {},
             key = path.join('/', file);

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -947,7 +947,22 @@
           return name.indexOf('node_modules') !== 0;
         });
 
-        list.forEach(function(file) {
+        var filterFiles = function(fn) {
+            var key = path.join('/', fn);
+            key = key.split(path.sep).join('/');
+
+            // Exclude hidden files and folders.
+            if (fn.indexOf('/.') >= 0) {
+              return false;
+            }
+
+            // Only include files in /www folder.
+            return /^\/(www\/|[^/]*$)/.test(key);
+        };
+
+        var filteredList = list.filter(filterFiles);
+
+        filteredList.forEach(function(file) {
           var obj = {},
             key = path.join('/', file);
 


### PR DESCRIPTION
Hi @masahirotanaka 

Please review this PR. 

Just to give you an example for one project, the total count of files in a sample project is 113 and files remaining count after applying filter is 33. So checksum is calculated for only those files.
