### PR TITLE
fix(monaca.js): Fix local files deletion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 CHANGELOG
 ====
 
+v1.1.10
+
+* monaca: Fixed local files deletion.
+
 v1.1.9
 ----
  * monaca: Fixed `Monaca.startRemoteBuild()` API to support placeholders.
@@ -41,7 +45,7 @@ v1.1.5-rc.1
 ----
  * monaca: Added `Monaca.getCurrentUser()` API.
  * localkit: Added `Localkit.generateOneTimePassword()`, `Localkit.validateOneTimePassword()`, `Localkit.generateLocalPairingKey()` API.
- * monaca: Fixed the POST parameter not sent to the server for some reason. 
+ * monaca: Fixed the POST parameter not sent to the server for some reason.
 
 v1.1.4
 ----

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1460,25 +1460,24 @@
             var allowFiles = this._filterIgnoreList(projectDir);
 
             // Temporary array for reverse loop.
-            var TempArr = [];
-
-            for (var Key in localFiles){
-                TempArr.push(Key);
+            var tempArr = [];
+            for (var key in localFiles){
+                tempArr.push(key);
             }
 
             // Reverse loop needed to first delete the files, then the folders.
-            for (var f = TempArr.length-1; f>=0; f--) {
+            for (var f = tempArr.length-1; f >= 0; f--) {
               // If file is not present on Monaca cloud but is present locally and it is not listed under .monacaignore, then it must be deleted.
-              if (!remoteFiles.hasOwnProperty(TempArr[f]) && allowFiles.indexOf((os.platform() === 'win32' ? projectDir.replace(/\\/g,"/") : projectDir) + TempArr[f]) >= 0) {
-                filesToBeDeleted[TempArr[f]] = localFiles[TempArr[f]];
+              if (!remoteFiles.hasOwnProperty(tempArr[f]) && allowFiles.indexOf((os.platform() === 'win32' ? projectDir.replace(/\\/g,"/") : projectDir) + tempArr[f]) >= 0) {
+                filesToBeDeleted[tempArr[f]] = localFiles[tempArr[f]];
                 if (options && !options.dryrun && options.delete) {
-                  try {
-                    fs.unlinkSync(path.join(projectDir, TempArr[f]));
-                    console.log("deleted file-> " + path.join(projectDir, TempArr[f]));
+                  if (localFiles[tempArr[f]].type === 'file') {
+                    fs.unlinkSync(path.join(projectDir, tempArr[f]));
+                    console.log("deleted file-> " + path.join(projectDir, tempArr[f]));
                   }
-                  catch(err) {
-                    fs.rmdir(path.join(projectDir, TempArr[f]));
-                    console.log("deleted folder-> " + path.join(projectDir, TempArr[f]));
+                  else if (localFiles[tempArr[f]].type === 'dir') {
+                    fs.rmdir(path.join(projectDir, tempArr[f]));
+                    console.log("deleted folder-> " + path.join(projectDir, tempArr[f]));
                   }
                 }
               }

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -2353,7 +2353,7 @@
 
       var downloadProject = function() {
         outerDeferred.notify('Downloading changes from the cloud...');
-        return this.downloadProject(arg.path,{ 'delete' : true });
+        return this.downloadProject(arg.path, { 'delete' : true });
       }.bind(this);
 
       this.isMonacaProject(arg.path)


### PR DESCRIPTION
@masahirotanaka @knight9999 please take a look at this.

The problem was that local files weren't deleted after `Build Settings` was closed. This deletes the files and the folders. The concept is the following:
- Files and folders to be deleted are ordered like this: `folder first -> folder content next`, this can cause error during the deletion because, if the folder will be deleted, also it's content will be deleted. This will throw an error when the folder content will be processed for deletion.
- Using a reverse loop will solve this issue, keeping the computational cost low because every element needs to be checked once.

I already tested it, works fine.
