### PR TITLE
Download project options fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 CHANGELOG
 ====
 
+v1.1.11
+----
+* monaca: Added missing `options` to `downloadProject` method in `Monaca.startRemoteBuild` API.
+
 v1.1.10
 ----
  * monaca: Fixed .monaca/project_info.json not updated when syncing back from the Cloud.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monaca-lib",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Monaca cloud and localkit API bindings for JavaScript",
   "main": "./src/main.js",
   "scripts": {

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -2357,7 +2357,11 @@
 
       var downloadProject = function() {
         outerDeferred.notify('Downloading changes from the cloud...');
-        return this.downloadProject(arg.path);
+        var options = null;
+        if (arg.delete) {
+          options = {'delete' : true};
+        }
+        return this.downloadProject(arg.path, options);
       }.bind(this);
 
       this.isMonacaProject(arg.path)


### PR DESCRIPTION
@masahirotanaka please take a look at this.

It fixes the issues which was not deleting the local files, even if they were deleted in the cloud. It also solves the issue with the `splash screen` which was not allowing the app to build after the splash screen has been edited.
