### PR TITLE
monaca download minor bug fix

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -808,7 +808,7 @@
           var file = fs.createWriteStream(dest);
           response.pipe(file);
           file.on('finish', function() {
-            deferred.resolve(filename);
+            deferred.resolve(dest);
           });
           file.on('error', function(error) {
             deferred.reject(error);


### PR DESCRIPTION
@masahiro I guess we don't need the `filename` function back to the client but rather we want the `filename` string (`dest`).
