### PR TITLE
Errors refactor

### DIFF
--- a/src/localkit.js
+++ b/src/localkit.js
@@ -420,7 +420,7 @@
     var deferred = Q.defer();
 
     if (!this.monaca._loggedIn) {
-      deferred.reject('Must be logged in to use this method.');
+      deferred.reject(new Error('Must be logged in to use this method.'));
     }
     else {
       this._interval = setInterval(this._sendBeacon.bind(this), config.beacon_send_interval);
@@ -544,7 +544,7 @@
           deferred.resolve(projectId);
         }
         else {
-          deferred.reject('No such project.');
+          deferred.reject(new Error('No such project.'));
         }
       }.bind(this),
       function(error) {
@@ -606,7 +606,7 @@
       }.bind(this))[0];
 
     if (!projectId) {
-      return Q.reject('No such project.');
+      return Q.reject(new Error('No such project.'));
     }
     else {
       var project = this.projects.getProjectById(projectId),
@@ -684,7 +684,7 @@
       }.bind(this))[0];
 
     if (!projectId) {
-      return Q.reject('No such project.');
+      return Q.reject(new Error('No such project.'));
     }
     else {
       var project = this.projects.getProjectById(projectId),
@@ -718,7 +718,7 @@
       }.bind(this))[0];
 
     if (!projectId) {
-      return Q.reject('No such project.');
+      return Q.reject(new Error('No such project.'));
     }
     else {
       var project = this.projects.getProjectById(projectId);
@@ -750,7 +750,7 @@
     this.monaca.getLocalProjectId(projectPath).then(
       function(projectId) {
         if (!this.projects.hasOwnProperty(projectId)) {
-          deferred.reject('No project with id: ' + projectId);
+          deferred.reject(new Error('No project with id: ' + projectId));
         }
         else {
           try {
@@ -953,7 +953,7 @@
       );
     }
     else {
-      deferred.reject('No project with id: ' + projectId);
+      deferred.reject(new Error('No project with id: ' + projectId));
     }
 
     return deferred.promise;
@@ -972,7 +972,7 @@
     var deferred = Q.defer();
 
     if (!this.projects.hasOwnProperty(projectId)) {
-      deferred.reject('No project width id: ' + projectId);
+      deferred.reject(new Error('No project width id: ' + projectId));
     }
     else {
       var projectPath = this.projects.getProjectById(projectId).path,
@@ -989,7 +989,7 @@
         absoluteProjectPath = path.resolve(projectPath);
 
       if (absoluteFilePath.indexOf(absoluteProjectPath) !== 0) {
-        deferred.reject('File is outside of project path.');
+        deferred.reject(new Error('File is outside of project path.'));
       }
       else {
         fs.exists(filePath, function(exists) {

--- a/src/localkit/localAuth.js
+++ b/src/localkit/localAuth.js
@@ -76,10 +76,10 @@
       now = Date.now();
 
     if (typeof password === 'undefined') {
-      return Q.reject('No such password.');
+      return Q.reject(new Error('No such password.'));
     }
     else if (now > password.expires) {
-      return Q.reject('Password has expired.');
+      return Q.reject(new Error('Password has expired.'));
     }
 
     delete this.passwords[passwordHash];

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -792,48 +792,73 @@
         }
 
         if (data.status === 'ok') {
-          var platformContent = data.result[platform];
 
-          if (!platformContent) {
-            return deferred.reject(new Error("Specified platform is not supported or doesn\'t exist."));
-          } else if (platformContent.has_remaining_slot !== true) {
-            return deferred.reject(new Error("Your plan does not allow further builds at the moment. Please upgrade your account to start build, or try again later."));
-          } else if (platformContent.is_start_file_exist !== true) {
-            return deferred.reject(new Error("Your project is missing the startup file (usually index.html)."));
-          } else if (platformContent.manifest_error) {
-            return deferred.reject(new Error("Your AndroidManifest.xml has an invalid value. Please fix it and try again."));
-          } else if (typeof(platformContent.can_build_for[buildType]) === 'undefined') {
-            return deferred.reject(new Error(platform + " " + buildType + " build is not supported or doesn\'t exist."));
-          } else if (platform === 'android') {
-            if (platformContent.is_versionname_valid !== true) {
-              return deferred.reject(new Error("Version name is invalid."));
-            } else if (buildType === 'release' && platformContent.has_keysetting !== true) {
-              return deferred.reject(new Error("Missing KeyStore configuration. Configure remote build and try again."));
+          var checkError = function() {
+            var platformContent = data.result[platform];
+
+            if (!platformContent) {
+              return 'Specified platform is not supported or doesn\'t exist.';
             }
-          } else if (platform === 'ios') {
-            if (platformContent.info_plist_error) {
-              return deferred.reject(new Error("Your Info.plist file has an invalid content. Please fix it and try again."));
-            } else if (platformContent.has_splash_and_icons !== true) {
-              return deferred.reject(new Error("Your project is missing splash screens and/or icons. Please open remote build settings to configure."));
-            } else if (buildType === "debug") {
-              if (platformContent['has_dev_provisioning'] !== true) {
-                return deferred.reject(new Error("Missing dev provisioning file. Please upload it from remote build settings."));
-              } else if (platformContent['dev_provisioning_error'] === true) {
-                return deferred.reject(new Error("Error in dev provisioning file. Please upload again from remote build settings."));
-              }
-            } else if (buildType === "debugger") {
-              if (platformContent['has_debug_provisioning'] !== true) {
-                return deferred.reject(new Error("Missing debug provisioning file. Please upload it from remote build settings."));
-              } else if (platformContent['debug_provisioning_error'] === true) {
-                return deferred.reject(new Error("Error in debug provisioning file. Please upload again from remote build settings."));
-              }
-            } else if (platformContent['has_' + buildType + '_provisioning'] !== true) {
-              return deferred.reject(new Error("Missing " + buildType + " provisioning file. Please upload it from remote build settings."));
-            } else if (platformContent[buildType + '_provisioning_error'] === true) {
-              return deferred.reject(new Error("Error in" + buildType + " provisioning file. Please upload again from remote build settings."));
+            if (!platformContent.has_remaining_slot) {
+              return 'Your plan does not allow further builds at the moment. Please upgrade your account to start build, or try again later.';
             }
+            if (!platformContent.is_start_file_exist) {
+              return 'Your project is missing the startup file (usually index.html).';
+            }
+            if (platformContent.manifest_error) {
+              return 'Your AndroidManifest.xml has an invalid value. Please fix it and try again.';
+            }
+            if (typeof platformContent.can_build_for[buildType] === 'undefined') {
+              return platform + ' ' + buildType + ' build is not supported or doesn\'t exist.';
+            }
+            if (platform === 'android') {
+              if (!platformContent.is_versionname_valid) {
+                return 'Version name is invalid.';
+              }
+              if (buildType === 'release' && !platformContent.has_keysetting) {
+                return 'Missing KeyStore configuration. Configure remote build and try again.';
+              }
+            }
+            if (platform === 'ios') {
+              if (platformContent.info_plist_error) {
+                return 'Your Info.plist file has an invalid content. Please fix it and try again.';
+              }
+              if (!platformContent.has_splash_and_icons) {
+                return 'Your project is missing splash screens and/or icons. Please open remote build settings to configure.';
+              }
+              if (buildType === 'debug') {
+                if (!platformContent.has_dev_provisioning) {
+                  return 'Missing dev provisioning file. Please upload it from remote build settings.';
+                }
+                if (platformContent.dev_provisioning_error) {
+                  return 'Error in dev provisioning file. Please upload again from remote build settings.';
+                }
+              }
+              if (buildType === 'debugger') {
+                if (!platformContent.has_debug_provisioning) {
+                  return 'Missing debug provisioning file. Please upload it from remote build settings.';
+                }
+                if (platformContent.debug_provisioning_error) {
+                  return 'Error in debug provisioning file. Please upload again from remote build settings.';
+                }
+              }
+              if (!platformContent['has_' + buildType + '_provisioning']) {
+                return 'Missing ' + buildType + ' provisioning file. Please upload it from remote build settings.';
+              }
+              if (platformContent[buildType + '_provisioning_error']) {
+                return 'Error in' + buildType + ' provisioning file. Please upload again from remote build settings.';
+              }
+            }
+
+            return '';
+          };
+
+          var errorMessage = checkError();
+          if (errorMessage) {
+            return deferred.reject(new Error(errorMessage));
+          } else {
+            return deferred.resolve(data);
           }
-          deferred.resolve(data);
         } else {
           return deferred.reject(new Error(data.status + " - " + data.message));
         }

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -327,7 +327,7 @@
     }
 
     if (!this._loggedIn) {
-      deferred.reject('Must be logged in to use this method.');
+      deferred.reject(new Error('Must be logged in to use this method.'));
     }
     else {
       this.getConfig('http_proxy').then(
@@ -408,7 +408,7 @@
                 deferred.reject(JSON.parse(body));
               }
               catch (e) {
-                deferred.reject('Error code: ' + response.statusCode);
+                deferred.reject(new Error('Error code: ' + response.statusCode));
               }
             }
           }
@@ -493,7 +493,7 @@
 
     fs.exists(localPath, function(exists) {
       if (!exists) {
-        deferred.reject('File does not exist.');
+        deferred.reject(new Error('File does not exist.'));
       }
       else {
         fs.readFile(localPath, function(error, data) {
@@ -586,7 +586,7 @@
           try {
             var _body = JSON.parse(body || '{}');
           } catch (e) {
-            deferred.reject("Not a JSON response");
+            deferred.reject(new Error('Not a JSON response.'));
           }
           if (error) {
             deferred.reject(error.code);
@@ -673,7 +673,7 @@
     this.getData('reloginToken').then(
       function(reloginToken) {
         if (typeof(reloginToken) !== 'string' || reloginToken === '') {
-          return deferred.reject("Not a valid relogin token.");
+          return deferred.reject(new Error('Not a valid relogin token.'));
         }
 
         this._login(reloginToken, options).then(
@@ -933,7 +933,7 @@
             deferred.reject(error);
           });
         } else {
-          deferred.reject("Not a valid file name");
+          deferred.reject(new Error('Not a valid file name.'));
         }
       })
 
@@ -1217,7 +1217,7 @@
     var deferred = Q.defer();
     fs.exists(destDir, function(exists) {
       if (exists && shell.ls(destDir).length > 0) {
-        deferred.reject('File or directory already exists and it contains files.');
+        deferred.reject(new Error('File or directory already exists and it contains files.'));
       }
       else {
         var success = true;
@@ -1764,7 +1764,7 @@
     }
 
     if (!params.platform) {
-      deferred.reject('Must specify build platform.');
+      deferred.reject(new Error('Must specify build platform.'));
     }
 
     var pollBuild = function(queueId) {
@@ -1892,7 +1892,7 @@
 
       fs.exists(destinationDir, function(exists) {
         if (exists) {
-          deferred.reject('Directory already exists');
+          deferred.reject(new Error('Directory already exists'));
         }
         else {
           deferred.resolve(destinationDir);
@@ -1984,7 +1984,7 @@
         deferred.resolve(configFile);
       }
       else {
-        deferred.reject('Unable to set config file: ' + parentDir + ' does not exist.');
+        deferred.reject(new Error('Unable to set config file: ' + parentDir + ' does not exist.'));
       }
     }.bind(this));
 
@@ -2397,7 +2397,7 @@
         var promise = promises.shift();
 
         if (!promise) {
-          return Q.reject('Config file is missing.');
+          return Q.reject(new Error('Config file is missing.'));
         }
 
         return promise.then(
@@ -2418,7 +2418,7 @@
         return hasConfigFile();
       },
       function() {
-        return Q.reject('"www" directory is missing.');
+        return Q.reject(new Error('"www" directory is missing.'));
       }
     );
   };
@@ -2506,7 +2506,7 @@
       this.isMonacaProject(arg.path)
         .catch(
           function() {
-            return Q.reject('Could not build since project is not a Monaca project or does not exist on disk.');
+            return Q.reject(new Error('Could not build since project is not a Monaca project or does not exist on disk.'));
           }
         )
         .then(relogin)

--- a/src/monaca/localProperties.js
+++ b/src/monaca/localProperties.js
@@ -67,7 +67,7 @@ var getProperty = function(projectDir, key) {
       );
     },
     function() {
-      deferred.reject('.monaca directory missing. This is not a Monaca project.');
+      deferred.reject(new Error('.monaca directory missing. This is not a Monaca project.'));
     }
   );
 
@@ -117,7 +117,7 @@ var setProperty = function(projectDir, key, value) {
       );
     },
     function() {
-      deferred.reject('.monaca directory missing. This is not a Monaca project.');
+      deferred.reject(new Error('.monaca directory missing. This is not a Monaca project.'));
     }
   );
 


### PR DESCRIPTION
@masahirotanaka I just wrapped all the error messages I found in public functions into new error objects. There are still some `reject(error.code)` but I think those are used in private methods so I think it's better to leave them like that.
