### PR TITLE
Added signup feature.

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,7 @@
 {
   "monaca": {
-    "default_api_root": "https://ide.monaca.mobi/api"
+    "default_api_root": "https://ide.monaca.mobi/api",
+    "web_api_root": "https://monaca.mobi/en/api"
   },
   "localkit": {
     "http_server_port": 8001,


### PR DESCRIPTION
@masahirotanaka This is working for s.monaca.mobi. I will update the URL and remove `rejectUnauthorized: false` when the API for monaca.mobi is updated. I'm not changing the language of the request (always `/en/api`) since the CLI is not translated to Japanese. Also, I'd probably need to implement some logic or add dependencies to detect the language.

 Do you think it's fine like this?
