### PR TITLE
Bug fix, small refactor and analytics feature.

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
   "monaca": {
-    "default_api_root": "https://ide.s.monaca.mobi/api",
-    "web_api_root": "https://s.monaca.mobi/en/api"
+    "default_api_root": "https://ide.monaca.mobi/api",
+    "web_api_root": "https://monaca.mobi/en/api"
   },
   "localkit": {
     "http_server_port": 8001,

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
   "monaca": {
-    "default_api_root": "https://ide.monaca.mobi/api",
-    "web_api_root": "https://monaca.mobi/en/api"
+    "default_api_root": "https://ide.s.monaca.mobi/api",
+    "web_api_root": "https://s.monaca.mobi/en/api"
   },
   "localkit": {
     "http_server_port": 8001,

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -440,7 +440,7 @@
       function(httpProxy) {
         var requestClient = request.defaults({
           qs: qs,
-          rejectUnauthorized: false, // DELETE
+          // rejectUnauthorized: false, // DELETE
           encoding: null,
           proxy: httpProxy,
           headers: {

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -202,7 +202,7 @@
   Monaca.prototype.reportAnalytics = function(report, resolvedValue) {
     return this.getTrackId().then(
       function(trackId) {
-        var form = extend({}, report, { event: 'monaca-local-' + report.event }, {
+        var form = extend({}, report, { event: 'monaca-lib-' + report.event }, {
           trackId: trackId,
           clientType: this.clientType,
           version: this.version,


### PR DESCRIPTION
@masahirotanaka This PR implements monaca-lib analytics part.
At the end I moved all the analytics calls to CLI in order to have more control. I'll make a PR in that repo and someone will have to implement it in LocalKit later.

While doing this I had to refactor the code a bit so we are more consistent with the http requests we do. Now we use `_post` and `_get` methods always. In order to do that, `_post` and `_get` return now the whole response (body + headers), not only the body as before. This refactor is made in 71c6c12

Also, there was a bug in `relogin` function that is now fixed.

From now on, when creating a monaca-lib instance we should provide clientType and clientVersion information, although this is optional so it doesn't break anything.

Since this also fixes a bug I think we should merge and test asap.
