### PR TITLE
Changed build order.

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -2250,7 +2250,7 @@
     var config = this.fetchProjectData(projectDir);
 
     if(!config.build) {
-      return Q.resolve(false);
+      return Q.resolve(projectDir);
     }
 
     var deferred = Q.defer();
@@ -2561,9 +2561,9 @@
     return checkDirectory()
       .then(fetchFile)
       .then(unzipFile)
+      .then(this.generateBuildConfigs.bind(this))
       .then(this.installTemplateDependencies.bind(this))
-      .then(this.installBuildDependencies.bind(this))
-      .then(this.generateBuildConfigs.bind(this));
+      .then(this.installBuildDependencies.bind(this));
   };
 
   /**


### PR DESCRIPTION
@masahirotanaka This just changes the order when creating a new project. If `npm` fails installing a package at least the project dir will be valid, having all the necessary configuration. This way the user could fix a specific boken dependency and still use the project.
