### PR TITLE
Resolve to PID when watching for changes.

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -2492,6 +2492,14 @@
           });
         }
       });
+
+      if(options.watch) {
+        deferred.resolve({
+          message: 'Watching directory "' + projectDir + '" for changes...',
+          pid: webpackProcess.pid
+        });
+      }
+
     } catch (error) {
       deferred.reject(error);
     }


### PR DESCRIPTION
@masahirotanaka Since the webpack process with `watch` option won't end automatically, this resolves to the process `pid` so it can be killed at any time from LocalKit. In CLI a simple `sigint` will kill it so the `pid` is not necessary.
