### PR TITLE
Remove AndroidManifest.xml error check for app build

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1000,9 +1000,6 @@
             if (!platformContent.is_start_file_exist) {
               return 'Your project is missing the startup file (usually index.html).';
             }
-            if (platformContent.manifest_error) {
-              return 'Your AndroidManifest.xml has an invalid value. Please fix it and try again.';
-            }
             if (typeof platformContent.can_build_for[buildType] === 'undefined') {
               return platform + ' ' + buildType + ' build is not supported or doesn\'t exist.';
             }


### PR DESCRIPTION
Please remove the AndroidManifest.xml error check , because for cordova6 build server does not use this manifest file and Monaca templates for cordova6 don't have the file.
