### PR TITLE
Remove Info.plist error check for app build

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1015,9 +1015,6 @@
               }
             }
             if (platform === 'ios') {
-              if (platformContent.info_plist_error) {
-                return 'Your Info.plist file has an invalid content. Please fix it and try again.';
-              }
               if (!platformContent.has_splash_and_icons) {
                 return 'Your project is missing splash screens and/or icons. Please open remote build settings to configure.';
               }


### PR DESCRIPTION
This check process is unnecessary for building app.
