### PR TITLE
Webpack prog

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -2491,7 +2491,7 @@
         }));
       });
 
-      deferred.resolve();
+      deferred.resolve(projectDir);
     } else {
        compiler.run(function(err, stats) {
         //console.log(stats.toString({colors: true}));

--- a/src/transpile.js
+++ b/src/transpile.js
@@ -1,0 +1,55 @@
+console.log(process.argv);
+
+var rl;
+
+var webpackConfigFile = process.argv[2];
+var watch = process.argv[3] === '--watch';
+
+var webpack = require(require('path').join(process.env.USER_CORDOVA, 'node_modules', 'webpack'));
+var webpackConfig = require(webpackConfigFile);
+
+var compiler = webpack(webpackConfig);
+var watchInstance;
+
+var outputStyle = {
+  chunks: false,
+  chunksModules: false,
+  reasons: false,
+  modules: false,
+  children: false,
+  warnings: false,
+  hash: false,
+  colors: true
+};
+
+if (watch) {
+  watchInstance = compiler.watch({}, function(err, stats) {
+    process.stdout.write(stats.toString(outputStyle));
+  });
+} else {
+  compiler.run(function(err, stats) {
+    process.stdout.write(stats.toString(outputStyle));
+    // if (process.platform === 'win32' && rl) {
+    //   rl.close();
+    // }
+  });
+}
+
+// if (process.platform === 'win32') {
+//   rl = require('readline').createInterface({
+//     input: process.stdin,
+//     output: process.stdout
+//   });
+
+//   rl.on('SIGINT', function() {
+//     // process.stdout.write('\nStopping http server...\n');
+//     rl.close();
+//     process.stderr.write('\nCanceled by the user.\n');
+//     // if (watchInstance) {
+//     //   watchInstance.close();
+//     // }
+//     //process.stderr.write('SIGINT\n');
+//     process.exit(1); // TODO: NICE MESSAGES
+//     //require('child_process').exec('taskkill /pid ' + process.pid + ' /T /F');
+//   });
+// }

--- a/src/transpile.js
+++ b/src/transpile.js
@@ -1,55 +1,29 @@
-console.log(process.argv);
-
-var rl;
-
 var webpackConfigFile = process.argv[2];
 var watch = process.argv[3] === '--watch';
 
 var webpack = require(require('path').join(process.env.USER_CORDOVA, 'node_modules', 'webpack'));
 var webpackConfig = require(webpackConfigFile);
 
-var compiler = webpack(webpackConfig);
-var watchInstance;
-
 var outputStyle = {
   chunks: false,
-  chunksModules: false,
-  reasons: false,
-  modules: false,
   children: false,
   warnings: false,
+  version: false,
   hash: false,
   colors: true
 };
 
+var compiler = webpack(webpackConfig);
+
 if (watch) {
-  watchInstance = compiler.watch({}, function(err, stats) {
-    process.stdout.write(stats.toString(outputStyle));
+  compiler.watch({
+    poll: false,
+    aggregateTimeout: 300
+  }, function(err, stats) {
+    process.send(stats.toString(outputStyle));
   });
 } else {
   compiler.run(function(err, stats) {
-    process.stdout.write(stats.toString(outputStyle));
-    // if (process.platform === 'win32' && rl) {
-    //   rl.close();
-    // }
+    process.send(stats.toString(outputStyle));
   });
 }
-
-// if (process.platform === 'win32') {
-//   rl = require('readline').createInterface({
-//     input: process.stdin,
-//     output: process.stdout
-//   });
-
-//   rl.on('SIGINT', function() {
-//     // process.stdout.write('\nStopping http server...\n');
-//     rl.close();
-//     process.stderr.write('\nCanceled by the user.\n');
-//     // if (watchInstance) {
-//     //   watchInstance.close();
-//     // }
-//     //process.stderr.write('SIGINT\n');
-//     process.exit(1); // TODO: NICE MESSAGES
-//     //require('child_process').exec('taskkill /pid ' + process.pid + ' /T /F');
-//   });
-// }


### PR DESCRIPTION
@masahirotanaka I think these are the last changes. Works in CLI/Localkit and Windows/OSX.
We don't need to bundle Node.js since it uses the Electron process itself.

This basically uses webpack programatically but it spawns that in a custom separate process where I have controll over webpack's output. The child process communicates with the parent through IPC and passes webpack's output. This is necessary for Localkit because if the child process prints directly to stdout it crashes (due to some Windows weird process stuff).

This is basically the same as spawning a new webpack process as we did before, the only difference is that, as mentioned, we have control over the spawned process and can prevent it from printing things to stdout.

This way we also have colors for Localkit output :smiley: 
