### PR TITLE
Escaped special characters on sync files.

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -427,7 +427,7 @@
     }
 
     // We have to append '/**' to get all the subdirectories recursively.
-    allFiles = glob.sync(projectDir + "/**",
+    allFiles = glob.sync(projectDir.replace(/[-[\]{}()*+?.,^$|#]/g, "\\$&") + "/**",
       {
         dot: true,
         ignore: ignoreList


### PR DESCRIPTION
@masahirotanaka please take a look at this when you have time.

It seems that if a project contains special characters in its path, they will be treated as part of a REGEX, breaking the upload/download functionality. This fix solves the issue by escaping special characters.

A new release of Localkit and CLI is also needed if this fix will be merged.
