### PR TITLE
change index.ejs => index.html

### DIFF
--- a/src/template/webpack.dev.angular2.js
+++ b/src/template/webpack.dev.angular2.js
@@ -101,7 +101,7 @@ module.exports = {
       name: ['app', 'vendor', 'polyfills']
     }),
     new HtmlWebpackPlugin({
-      template: 'src/public/index.ejs',
+      template: 'src/public/index.html',
       chunksSortMode: 'dependency'
     }),
     new ProgressBarPlugin()

--- a/src/template/webpack.prod.angular2.js
+++ b/src/template/webpack.prod.angular2.js
@@ -111,10 +111,8 @@ module.exports = {
       name: ['app', 'vendor', 'polyfills']
     }),
     new HtmlWebpackPlugin({
-      template: 'src/public/index.ejs',
+      template: 'src/public/index.html',
       chunksSortMode: 'dependency',
-      externalCSS: ['components/loader.css'],
-      externalJS: ['components/loader.js'],
       minify: {
         collapseWhitespace: true,
         conservativeCollapse: true,


### PR DESCRIPTION
確認したところ、ejsはloader.css/loader.jsのために採用したようでしたが、
- webpack.dev.config.js
- webpack.prod.config.js

ともに、直書きでも問題なく稼働しましたので、馴染みの少ないejsを使うよりも、html形式を使った方がいいと思います。特にwebアプリとして公開する場合、ローディング画面に何を出すか、などindex.htmlをさわることが増えるので、ejsで条件分岐をここに書くデメリットは大きいかと思います。
