### PR TITLE
Project clone/upload refactor

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1476,6 +1476,10 @@
                 }
               }.bind(this)))).then(
                 function() {
+                  return this.setProjectId(destDir, projectId);
+                }.bind(this)
+              ).then(
+                function() {
                   deferred.resolve(destDir);
                 },
                 function(error) {

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -2997,7 +2997,7 @@
             name: arg.name,
             description: arg.description || '',
             templateId: 'minimum',
-            isBuildOnly: true
+            isBuildOnly: false
           })
           .then(
             function(info) {

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -3052,8 +3052,8 @@
         if (arg.delete) {
           options = {'delete' : true};
         }
-        if (arg.transpile) {
-          options.transpile = true;
+        if (arg.skipTranspile) {
+          options.skipTranspile = true;
         }
         return this.uploadProject(arg.path, options);
       }.bind(this);

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1622,7 +1622,7 @@
   Monaca.prototype.checkModifiedFiles = function(projectDir, options) {
     var projectId;
 
-    return ((options && options.transpile) ? this.transpile(projectDir) : this.getProjectId(projectDir))
+    return ((options && options.skipTranspile) ? this.getProjectId(projectDir) : this.transpile(projectDir))
     .then(
       localProperties.get.bind(this, projectDir, 'project_id')
     )
@@ -1678,11 +1678,6 @@
           projectId: projectId
         });
       }.bind(this)
-    )
-    .catch (
-      function(err) {
-        return Q.reject(err);
-      }
     )
   };
 

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1726,6 +1726,7 @@
         if (options && !options.dryrun && options.delete) {
           this._deleteFileFromCloud(projectId, Object.keys(filesToBeDeleted)).then(
             function() {
+              console.log(Object.keys(filesToBeDeleted)
                 .map(function(f) {
                   return "deleted -> " + f;
                 })

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1622,7 +1622,8 @@
   Monaca.prototype.checkModifiedFiles = function(projectDir, options) {
     var deferred = Q.defer();
 
-    ((options && options.transpile) ? this.transpile(projectDir) : this.getProjectId(projectDir)).then(
+    ((options && options.transpile) ? this.transpile(projectDir) : this.getProjectId(projectDir))
+    .then(
       localProperties.get.bind(this, projectDir, 'project_id'),
       function(error) {
         deferred.reject(error);
@@ -1630,7 +1631,8 @@
     )
     .then(
       function(projectId) {
-        Q.all([this.getLocalProjectFiles(projectDir), this.getProjectFiles(projectId)]).then(
+        Q.all([this.getLocalProjectFiles(projectDir), this.getProjectFiles(projectId)])
+        .then(
           function(files) {
             var localFiles = files[0],
               remoteFiles = files[1];
@@ -1716,7 +1718,8 @@
   Monaca.prototype.uploadProject = function(projectDir, options) {
     var deferred = Q.defer();
 
-    this.checkModifiedFiles(projectDir, options).then(
+    this.checkModifiedFiles(projectDir, options)
+    .then(
       function(result) {
         var filesToBeDeleted = result.filesToBeDeleted,
           modifiedFiles = result.modifiedFiles,
@@ -1724,7 +1727,8 @@
           projectId = result.projectId;
 
         if (options && !options.dryrun && options.delete) {
-          this._deleteFileFromCloud(projectId, Object.keys(filesToBeDeleted)).then(
+          this._deleteFileFromCloud(projectId, Object.keys(filesToBeDeleted))
+          .then(
             function() {
               console.log(Object.keys(filesToBeDeleted)
                 .map(function(f) {
@@ -1776,7 +1780,8 @@
 
         Q.all(keys.map(qLimit(function(key) {
           return uploadFile(key);
-        }.bind(this)))).then(
+        }.bind(this))))
+        .then(
           function() {
             deferred.resolve(modifiedFiles);
           },

--- a/src/transpile.js
+++ b/src/transpile.js
@@ -25,5 +25,6 @@ if (watch) {
 } else {
   compiler.run(function(err, stats) {
     process.send(stats.toString(outputStyle));
+    process.exit(err || stats.hasErrors());
   });
 }

--- a/src/transpile.js
+++ b/src/transpile.js
@@ -25,6 +25,6 @@ if (watch) {
 } else {
   compiler.run(function(err, stats) {
     process.send(stats.toString(outputStyle));
-    process.exit(err || stats.hasErrors());
+    process.exit(+(err || stats.hasErrors()));
   });
 }


### PR DESCRIPTION
Changelog:
- [x]  Set original projectID on projectClone, linking the cloned project with the one in IDE.
- [x]  Allow cloned project to be accessible from IDE.
- [x]  Add `checkModifiedFiles` method to check differences between local/remote files.
- [x]  Refactor `uploadProject` method in order to use the new `checkModifiedFiles` method.
- [x]  Add transpiler support during files check.

To do:
- [x]  Fix transpiling performance issue in order to speed up the modified files check.
- [x]  Fix bug that freezes localkit when large projects need to be uploaded (need to also check CLI).

Related pull request:

https://github.com/monaca/monaca_localkit/pull/80
