### PR TITLE
Fixed frameworkVersion and cordovaVersion fetching.

### DIFF
--- a/src/localkit.js
+++ b/src/localkit.js
@@ -885,15 +885,19 @@
 
                 project.name = _project.name || project.name;
                 project.frameworkVersion = "";
-                try {
-                  project.frameworkVersion = require(path.join( project_path, '.monaca', 'project_info.json'))["framework_version"]
-                } catch(e) {}
                 project.cordovaVersion = "";
-                try {
-                  project.cordovaVersion = require(path.join( project_path, '.monaca', 'project_info.json'))["cordova_version"]
-                } catch(e) {}
 
-                deferred.resolve(project);
+                var content = fs.readFile(path.join(project_path, '.monaca', 'project_info.json'), function(err, data) {
+                  if (err) {
+                    console.log("Error while reading project_info.json: " + err);
+                  } else {
+                    var parsedContent = JSON.parse(data);
+                    project.frameworkVersion = parsedContent["framework_version"];
+                    project.cordovaVersion = parsedContent["cordova_version"];
+                  }
+
+                  deferred.resolve(project);
+                });
               },
               function(error) {
                 deferred.reject(error);


### PR DESCRIPTION
@masahirotanaka please take a look at this.

`require` is caching the first read value of `framework_version` and `cordova_version`.
This creates problems in case those two properties change as Monaca Debugger will still receive the original version and display warnings in certain cases.
This implementation solves the issue and reduces read operations on `project_info.json`.

Original bug report:

https://trello.com/c/AK2Sk50m/165-ios-monaca-6
