### PR TITLE
Fixed frameworkVersion and cordovaVersion pairing issue.

### DIFF
--- a/src/localkit.js
+++ b/src/localkit.js
@@ -885,13 +885,15 @@
 
                 project.name = _project.name || project.name;
                 project.frameworkVersion = "";
-                try {
-                  project.frameworkVersion = require(path.join( project_path, '.monaca', 'project_info.json'))["framework_version"]
-                } catch(e) {}
                 project.cordovaVersion = "";
+
+                delete require.cache[path.join( project_path, '.monaca', 'project_info.json')];
                 try {
-                  project.cordovaVersion = require(path.join( project_path, '.monaca', 'project_info.json'))["cordova_version"]
-                } catch(e) {}
+                  project.frameworkVersion = require(path.join( project_path, '.monaca', 'project_info.json'))["framework_version"];
+                  project.cordovaVersion = require(path.join( project_path, '.monaca', 'project_info.json'))["cordova_version"];
+                } catch (e) {
+                  console.error(e.message);
+                }
 
                 deferred.resolve(project);
               },


### PR DESCRIPTION
@frankdiox please take a look at this when you have time.

Require is caching the values of framework_version and cordova_version.
This creates problems in case those two properties change as Monaca Debugger will still receive the original version and display warnings in certain cases.
This implementation invalidates the cache for the specific file in which framework_version and cordova_version are contained.

Original bug report:

https://trello.com/c/AK2Sk50m/165-ios-monaca-6