### PR TITLE
Missing remote project fix

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1699,6 +1699,11 @@
         });
       }.bind(this)
     )
+    .catch(
+      function(e) {
+        return Q.reject(e);
+      }
+    );
   };
 
   /**

--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1222,6 +1222,17 @@
     return localProperties.get(projectDir, 'project_id');
   };
 
+    /**
+   * @method
+   * @memberof Monaca
+   * @description
+   *   Delete project ID.
+   * @return {Promise}
+   */
+  Monaca.prototype.deleteProjectId = function(projectDir) {
+    return localProperties.del(projectDir, 'project_id');
+  };
+
   /**
    * @method
    * @memberof Monaca
@@ -1718,7 +1729,6 @@
    */
   Monaca.prototype.uploadProject = function(projectDir, options) {
     var deferred = Q.defer();
-
     this.checkModifiedFiles(projectDir, options)
     .then(
       function(result) {

--- a/src/monaca/localProperties.js
+++ b/src/monaca/localProperties.js
@@ -58,6 +58,26 @@ var createDefaultMonacaStructure = function(directory) {
   return deferred.promise;
 };
 
+var delProperty = function(directory, property) {
+  var deferred = Q.defer();
+
+  if (property === 'project_id') {
+    var propertyFile = path.join(directory, '.monaca', 'local_properties.json');
+
+     fs.unlink(propertyFile, function(err) {
+        if (err) {
+          deferred.reject(new Error("Could not delete the property: " + err));
+        } else {
+          deferred.resolve();
+        }
+      });
+  } else {
+    deferred.reject(new Error("The required property cannot be deleted because it does not exist."));
+  }
+
+  return deferred.promise;
+};
+
 
 var getProperty = function(projectDir, key) {
   var deferred = Q.defer();
@@ -145,5 +165,6 @@ var setProperty = function(projectDir, key, value) {
 
 module.exports = {
   get: getProperty,
-  set: setProperty
+  set: setProperty,
+  del: delProperty
 };


### PR DESCRIPTION
The implemented functionality will give the ability to delete the project id a local project. Needed when the remote version of the project has been deleted and the local version cannot sync anymore with it.