### PR TITLE
Fix webpack setting templates which are broken on Windows.

### DIFF
--- a/src/template/webpack.dev.angular2.js
+++ b/src/template/webpack.dev.angular2.js
@@ -70,7 +70,7 @@ module.exports = {
         path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
         path.join(__dirname, 'src')
       ],
-      loader: ['css-to-string', ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')]
+      loaders: ['css-to-string', ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')]
     }, {
       test: /\.css$/,
       exclude: [

--- a/src/template/webpack.dev.angular2.js
+++ b/src/template/webpack.dev.angular2.js
@@ -66,12 +66,18 @@ module.exports = {
       loader: 'file?name=assets/[name].[hash].[ext]'
     }, {
       test: /\.css$/,
-      include: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
-      loaders: ['css-to-string', ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')]
+      include: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
+      loader: ['css-to-string', ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')]
     }, {
       test: /\.css$/,
-      exclude: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
-      loader:  ExtractTextPlugin.extract('style', 'css?sourceMap')
+      exclude: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
+      loader: ExtractTextPlugin.extract('style', 'css?sourceMap')
     }, {
       test: /\.json$/,
       loader: 'json'

--- a/src/template/webpack.dev.react.js
+++ b/src/template/webpack.dev.react.js
@@ -79,11 +79,17 @@ module.exports = {
       loader: 'file?name=assets/[name].[hash].[ext]'
     }, {
       test: /\.css$/,
-      include: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
+      include: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
       loader: ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')
     }, {
       test: /\.css$/,
-      exclude: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
+      exclude: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
       loader: ExtractTextPlugin.extract('style', 'css?sourceMap')
     }, {
       test: /\.json$/,

--- a/src/template/webpack.dev.vue.js
+++ b/src/template/webpack.dev.vue.js
@@ -67,11 +67,17 @@ module.exports = {
       loader: 'file?name=assets/[name].[hash].[ext]'
     }, {
       test: /\.css$/,
-      include: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
+      include: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
       loader: ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')
     }, {
       test: /\.css$/,
-      exclude: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
+      exclude: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
       loader: ExtractTextPlugin.extract('style', 'css?sourceMap')
     }, {
       test: /\.json$/,

--- a/src/template/webpack.prod.angular2.js
+++ b/src/template/webpack.prod.angular2.js
@@ -71,12 +71,18 @@ module.exports = {
       loader: 'file?name=assets/[name].[hash].[ext]'
     }, {
       test: /\.css$/,
-      include: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
-      loaders: ['css-to-string', ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')]
+      include: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
+      loader: ['css-to-string', ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')]
     }, {
       test: /\.css$/,
-      exclude: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
-      loader:  ExtractTextPlugin.extract('style', 'css?sourceMap')
+      exclude: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
+      loader: ExtractTextPlugin.extract('style', 'css?sourceMap')
     }, {
       test: /\.json$/,
       loader: 'json'

--- a/src/template/webpack.prod.angular2.js
+++ b/src/template/webpack.prod.angular2.js
@@ -75,7 +75,7 @@ module.exports = {
         path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
         path.join(__dirname, 'src')
       ],
-      loader: ['css-to-string', ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')]
+      loaders: ['css-to-string', ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')]
     }, {
       test: /\.css$/,
       exclude: [

--- a/src/template/webpack.prod.react.js
+++ b/src/template/webpack.prod.react.js
@@ -81,11 +81,17 @@ module.exports = {
       loader: 'file?name=assets/[name].[hash].[ext]'
     }, {
       test: /\.css$/,
-      include: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
+      include: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
       loader: ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')
     }, {
       test: /\.css$/,
-      exclude: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
+      exclude: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
       loader: ExtractTextPlugin.extract('style', 'css?sourceMap')
     }, {
       test: /\.json$/,

--- a/src/template/webpack.prod.vue.js
+++ b/src/template/webpack.prod.vue.js
@@ -69,11 +69,17 @@ module.exports = {
       loader: 'file?name=assets/[name].[hash].[ext]'
     }, {
       test: /\.css$/,
-      include: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
+      include: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
       loader: ExtractTextPlugin.extract('style', 'css?importLoaders=1&-raw!postcss')
     }, {
       test: /\.css$/,
-      exclude: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
+      exclude: [
+        path.join(__dirname, 'node_modules', 'onsenui', 'css-components-src', 'src'),
+        path.join(__dirname, 'src')
+      ],
       loader: ExtractTextPlugin.extract('style', 'css?sourceMap')
     }, {
       test: /\.json$/,


### PR DESCRIPTION
@adamkozuch @andipavllo (Cc: @frandiox @masahirotanaka @keijiodagawa )
This PR fixes monaca/monaca-cli#83 and OnsenUI/OnsenUI#2037.

The current webpack settings have the following line,
```js
include: [/\/onsen-css-components.css$/, path.join(__dirname, 'src')],
```
but this works only on Linux/macOS since `/\/onsen-css-components.css$/` contains a platform-dependent path delimiter `/`.
In Windows, users will have a path like `C:\Users\Foo\Documents\node_modules\onsenui\css-components-src\src\onsen-css-components.css` but it does not match `/\/onsen-css-components.css$/`.
To prevent this, we have to use `path.join('foo', 'bar')` which uses `/` on Linux/macOS and `\` on Windows.

I tested the new webpack settings which this PR provides and they worked fine on both macOS and Windows.
Could you merge this and release new versions of `monaca-lib`, Monaca CLI and Monaca Localkit?