### PR TITLE
feat: MN-3657. Support lacking description in config.xml

### DIFF
--- a/src/monaca.js
+++ b/src/monaca.js
@@ -1984,7 +1984,7 @@
                     var projectConfig = {
                       name: result.widget.name[0],
                       directory: projectDir,
-                      description: result.widget.description[0],
+                      description: result.widget.description ? result.widget.description[0] : '',
                       projectId: projectId
                     };
 


### PR DESCRIPTION
config.xmlがdescriptionが空でもエラーにならないようにしました。
そもそもこのdescriptionはデバッガー側で使っていないようなのですが、一応、これまで同様に送るようにしています。

（ローカル環境では、この修正で、Localkitが正常に動作し、descriptionがなくても、デバッガーが固まらなくなった
ことは確認しています）