### PR TITLE
feat: Bump to 4.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@ Monaca Cloud API
 
 This is a library used to communicate with the Monaca Cloud REST API.
 
+Git Submodule
+-------------
+
+This library uses git submodules.
+Please following command.
+
+```
+$ git submodule update 
+```
+or initially 
+```
+$ git submodule --init -recursive
+```
+
 Initialization
 -------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "monaca-lib",
-  "version": "4.1.2",
+  "version": "4.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monaca-lib",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Monaca cloud and localkit API bindings for JavaScript",
   "main": "./src/main.js",
   "scripts": {


### PR DESCRIPTION
This PR changes only package version (and package-lock version) to 4.1.4

Because the previous version 4.1.3 is uploaded to npm publish without submodule. (i.e. template/blank files)
We need to upload again to npm. This new version is just for this purpose.
